### PR TITLE
Update instructions for TextMate2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A very simple SVG textmate bundle.
 
 I think some of the original stuff came from robin@berjon.com
 
-    cd ~/"Library/Application Support/TextMate/Bundles/"
+    cd ~/"Library/Application Support/TextMate/Managed/Bundles/"
     git clone git://github.com/grorg/svg-tmbundle.git SVG.tmbundle
     osascript -e 'tell app "TextMate" to reload bundles'
 


### PR DESCRIPTION
I think the path for bundles changed in TextMate2, thus, I updated the instructions in the readme
