### PR TITLE
Update instructions for TextMate2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ A very simple SVG textmate bundle.
 
 I think some of the original stuff came from robin@berjon.com
 
+To install:
+
     cd ~/"Library/Application Support/TextMate/Managed/Bundles/"
     git clone git://github.com/grorg/svg-tmbundle.git SVG.tmbundle
-    osascript -e 'tell app "TextMate" to reload bundles'
+    open SVG.tmbundle
 
+Then TextMate will open and ask you if you want to install the SVG bundle—click on `Yes`


### PR DESCRIPTION
Apparently the previous apple script no longer works, instead TextMate needs to be opened for the bundle to be installed https://stackoverflow.com/questions/8930984/error-running-osascript-e-tell-app-textmate-to-reload-bundles

Someone also reported this error on 04573a0535a0b91ae0b214def673468e62958c66
